### PR TITLE
Fix/use dfrac instead of frac

### DIFF
--- a/rubberize/latexer/calls/sympy_calls.py
+++ b/rubberize/latexer/calls/sympy_calls.py
@@ -112,7 +112,7 @@ def _diff(visitor: "ExprVisitor", call: ast.Call) -> Optional[ExprLatex]:
 
     opd = visitor.visit_opd(func_value, rank)
     diffs_latex = [
-        r"\frac{\mathrm{d}}{\mathrm{d}" + visitor.visit(a).latex + "}"
+        r"\dfrac{\mathrm{d}}{\mathrm{d}" + visitor.visit(a).latex + "}"
         for a in args
     ]
     diffs_latex.reverse()

--- a/rubberize/latexer/expr_rules.py
+++ b/rubberize/latexer/expr_rules.py
@@ -176,7 +176,7 @@ BIN_OPS: dict[type[ast.operator], _BinOpRule] = {
     ast.Mult: _BinOpRule("", r" \cdot ", ""),
     ast.MatMult: _BinOpRule("", r" \cdot ", ""),
     # pylint: disable-next=line-too-long
-    ast.Div: _BinOpRule(r"\frac{", "}{", "}", left=_BinOpdRule(wrap=False), right=_BinOpdRule(wrap=False)),
+    ast.Div: _BinOpRule(r"\dfrac{", "}{", "}", left=_BinOpdRule(wrap=False), right=_BinOpdRule(wrap=False)),
     ast.Mod: _BinOpRule("", r" \mathbin{\%} ", "", right=_BinOpdRule(non_assoc=True)),
     # pylint: disable-next=line-too-long
     ast.Pow: _BinOpRule("", "^{", "}", left=_BinOpdRule(non_assoc=True), right=_BinOpdRule(wrap=False)),
@@ -186,7 +186,7 @@ BIN_OPS: dict[type[ast.operator], _BinOpRule] = {
     ast.BitXor: _BinOpRule("", r" \oplus ", ""),
     ast.BitAnd: _BinOpRule("", r" \mathbin{\&} ", ""),
     # pylint: disable-next=line-too-long
-    ast.FloorDiv: _BinOpRule(r"\left\lfloor\frac{", "}{", r"}\right\rfloor", left=_BinOpdRule(wrap=False), right=_BinOpdRule(wrap=False), is_wrapped=True),
+    ast.FloorDiv: _BinOpRule(r"\left\lfloor\dfrac{", "}{", r"}\right\rfloor", left=_BinOpdRule(wrap=False), right=_BinOpdRule(wrap=False), is_wrapped=True),
 }
 # fmt: on
 

--- a/rubberize/latexer/latex_patterns.py
+++ b/rubberize/latexer/latex_patterns.py
@@ -69,7 +69,7 @@ def is_units_latex(latex: str) -> bool:
         r"(?:\\mathrm{[^}]+}(?:\^{-?\d+})?(?:\s*(?:\\,|\\cdot)\s*)?)+"
     )
 
-    frac_match = re.fullmatch(r"\\frac{(.+?)}{(.+?)}", latex)
+    frac_match = re.fullmatch(r"\\(?:d)?frac{(.+?)}{(.+?)}", latex)
     if frac_match:
         num, den = frac_match.groups()
         return re.fullmatch(units_pattern, den) is not None and (

--- a/rubberize/latexer/objects/builtin_objects.py
+++ b/rubberize/latexer/objects/builtin_objects.py
@@ -152,7 +152,7 @@ def _convert_fraction(obj: Fraction) -> ExprLatex:
     numerator = convert_int(obj.numerator)
     denominator = convert_int(obj.denominator)
     return ExprLatex(
-        r"\frac{" + numerator.latex + "}{" + denominator.latex + "}", DIV_RANK
+        r"\dfrac{" + numerator.latex + "}{" + denominator.latex + "}", DIV_RANK
     )
 
 

--- a/rubberize/latexer/objects/pint_objects.py
+++ b/rubberize/latexer/objects/pint_objects.py
@@ -91,7 +91,7 @@ def _reformat_units(units_latex: str) -> str:
     if not config.use_inline_units:
         return units_latex
 
-    match = re.match(r"\\frac{(.*)}{(.*)}", units_latex)
+    match = re.match(r"\\(?:d)?frac{(.*)}{(.*)}", units_latex)
     if not match:
         return units_latex
 


### PR DESCRIPTION
Updates all fraction representations to use `\dfrac` instead of `\frac`. Since `\dfrac` ensures a consistent display style by using full-size fractions in both inline and display math, it avoids inconsistencies where inline fractions appear too small.

Rubberize primarily involves structured mathematical expressions rather than compact inline text, so `\dfrac` is the more appropriate choice.