### PR TITLE
fix: call converter ranks

### DIFF
--- a/rubberize/latexer/calls/builtin_calls.py
+++ b/rubberize/latexer/calls/builtin_calls.py
@@ -18,6 +18,7 @@ from rubberize.latexer.ranks import (
     BELOW_POW_RANK,
     BELOW_MULT_RANK,
     BELOW_ADD_RANK,
+    VALUE_RANK,
 )
 
 if TYPE_CHECKING:
@@ -35,16 +36,17 @@ def eval_and_convert(
     return convert_object(obj)
 
 
+# pylint: disable-next=too-many-arguments
 def wrap(
     visitor: "ExprVisitor",
     call: ast.Call,
     prefix: str,
     suffix: str,
     sep: str = r",\, ",
+    *,
+    rank: int = VALUE_RANK,
 ) -> ExprLatex:
     """Common converter that adds prefix and suffix to args."""
-
-    rank = get_rank(call)
 
     args_latex = [visitor.visit(a).latex for a in call.args]
     latex = format_elts(args_latex, sep, (prefix, suffix))
@@ -52,10 +54,10 @@ def wrap(
     return ExprLatex(latex, rank)
 
 
-def rename(visitor: "ExprVisitor", call: ast.Call, name: str) -> ExprLatex:
+def rename(
+    visitor: "ExprVisitor", call: ast.Call, name: str, *, rank: int = VALUE_RANK
+) -> ExprLatex:
     """Common converter that only changes the operator name."""
-
-    rank = get_rank(call)
 
     args_latex = [visitor.visit(a).latex for a in call.args]
     latex = name + format_elts(args_latex, r",\, ", (r"\left(", r"\right)"))
@@ -181,17 +183,18 @@ def _get_range_args(call: ast.Call) -> tuple[ast.expr, ast.expr, ast.expr]:
     return call.args[0], call.args[1], call.args[2]
 
 
-def _exp(visitor: "ExprVisitor", call: ast.Call) -> ExprLatex:
+def _exp(visitor: "ExprVisitor", call: ast.Call) -> Optional[ExprLatex]:
     """Convert an `exp` call."""
 
+    rank = BELOW_POW_RANK
     assert get_id(call.func) == "exp"
 
     if isinstance(call.args[0], ast.BinOp) and isinstance(
         call.args[0].op, ast.Div
     ):
-        return unary(visitor, call, r"\exp ")
+        return rename(visitor, call, r"\exp ")
 
-    return wrap(visitor, call, "e^{", "}")
+    return wrap(visitor, call, "e^{", "}", rank=rank)
 
 
 def _log(visitor: "ExprVisitor", call: ast.Call) -> ExprLatex:
@@ -288,8 +291,8 @@ register_call_converter("log", _log)
 register_call_converter("log10", lambda v, c: unary(v, c, r"\log"))
 register_call_converter("log1p", lambda v, c: wrap(v, c, r"\ln \left(1 +", r"\right)"))
 register_call_converter("log2", lambda v, c: unary(v, c, r"\log_{2} "))
-register_call_converter("sqrt", lambda v, c: wrap(v, c, r"\sqrt{", "}"))
-register_call_converter("cbrt", lambda v, c: wrap(v, c, r"\sqrt[3]{", "}"))
+register_call_converter("sqrt", lambda v, c: wrap(v, c, r"\sqrt{", "}", rank=BELOW_POW_RANK))
+register_call_converter("cbrt", lambda v, c: wrap(v, c, r"\sqrt[3]{", "}", rank=BELOW_POW_RANK))
 register_call_converter("sum", _sum_prod)
 register_call_converter("fsum", _sum_prod)
 register_call_converter("prod", _sum_prod)

--- a/rubberize/latexer/calls/convert_call.py
+++ b/rubberize/latexer/calls/convert_call.py
@@ -24,7 +24,6 @@ from rubberize.config import config
 from rubberize.latexer.expr_latex import ExprLatex
 from rubberize.latexer.formatters import format_name, format_elts
 from rubberize.latexer.node_helpers import get_id
-from rubberize.latexer.ranks import get_rank
 
 if TYPE_CHECKING:
     from rubberize.latexer.node_visitors import ExprVisitor
@@ -94,4 +93,4 @@ def convert_call(visitor: "ExprVisitor", call: ast.Call) -> ExprLatex:
     elts_latex = [visitor.visit(a).latex for a in call.args]
     args_latex = format_elts(elts_latex, r",\, ", (r"\left(", r"\right)"))
 
-    return ExprLatex(name_latex + " " + args_latex, get_rank(call))
+    return ExprLatex(name_latex + " " + args_latex)

--- a/rubberize/latexer/calls/sympy_calls.py
+++ b/rubberize/latexer/calls/sympy_calls.py
@@ -112,7 +112,7 @@ def _diff(visitor: "ExprVisitor", call: ast.Call) -> Optional[ExprLatex]:
 
     opd = visitor.visit_opd(func_value, rank)
     diffs_latex = [
-        r"\dfrac{\mathrm{d}}{\mathrm{d}" + visitor.visit(a).latex + "}"
+        r"\frac{\mathrm{d}}{\mathrm{d}" + visitor.visit(a).latex + "}"
         for a in args
     ]
     diffs_latex.reverse()

--- a/rubberize/latexer/expr_rules.py
+++ b/rubberize/latexer/expr_rules.py
@@ -176,7 +176,7 @@ BIN_OPS: dict[type[ast.operator], _BinOpRule] = {
     ast.Mult: _BinOpRule("", r" \cdot ", ""),
     ast.MatMult: _BinOpRule("", r" \cdot ", ""),
     # pylint: disable-next=line-too-long
-    ast.Div: _BinOpRule(r"\dfrac{", "}{", "}", left=_BinOpdRule(wrap=False), right=_BinOpdRule(wrap=False)),
+    ast.Div: _BinOpRule(r"\frac{", "}{", "}", left=_BinOpdRule(wrap=False), right=_BinOpdRule(wrap=False)),
     ast.Mod: _BinOpRule("", r" \mathbin{\%} ", "", right=_BinOpdRule(non_assoc=True)),
     # pylint: disable-next=line-too-long
     ast.Pow: _BinOpRule("", "^{", "}", left=_BinOpdRule(non_assoc=True), right=_BinOpdRule(wrap=False)),
@@ -186,7 +186,7 @@ BIN_OPS: dict[type[ast.operator], _BinOpRule] = {
     ast.BitXor: _BinOpRule("", r" \oplus ", ""),
     ast.BitAnd: _BinOpRule("", r" \mathbin{\&} ", ""),
     # pylint: disable-next=line-too-long
-    ast.FloorDiv: _BinOpRule(r"\left\lfloor\dfrac{", "}{", r"}\right\rfloor", left=_BinOpdRule(wrap=False), right=_BinOpdRule(wrap=False), is_wrapped=True),
+    ast.FloorDiv: _BinOpRule(r"\left\lfloor\frac{", "}{", r"}\right\rfloor", left=_BinOpdRule(wrap=False), right=_BinOpdRule(wrap=False), is_wrapped=True),
 }
 # fmt: on
 

--- a/rubberize/latexer/latex_patterns.py
+++ b/rubberize/latexer/latex_patterns.py
@@ -69,7 +69,7 @@ def is_units_latex(latex: str) -> bool:
         r"(?:\\mathrm{[^}]+}(?:\^{-?\d+})?(?:\s*(?:\\,|\\cdot)\s*)?)+"
     )
 
-    frac_match = re.fullmatch(r"\\(?:d)?frac{(.+?)}{(.+?)}", latex)
+    frac_match = re.fullmatch(r"\\frac{(.+?)}{(.+?)}", latex)
     if frac_match:
         num, den = frac_match.groups()
         return re.fullmatch(units_pattern, den) is not None and (

--- a/rubberize/latexer/objects/builtin_objects.py
+++ b/rubberize/latexer/objects/builtin_objects.py
@@ -152,7 +152,7 @@ def _convert_fraction(obj: Fraction) -> ExprLatex:
     numerator = convert_int(obj.numerator)
     denominator = convert_int(obj.denominator)
     return ExprLatex(
-        r"\dfrac{" + numerator.latex + "}{" + denominator.latex + "}", DIV_RANK
+        r"\frac{" + numerator.latex + "}{" + denominator.latex + "}", DIV_RANK
     )
 
 

--- a/rubberize/latexer/objects/pint_objects.py
+++ b/rubberize/latexer/objects/pint_objects.py
@@ -91,7 +91,7 @@ def _reformat_units(units_latex: str) -> str:
     if not config.use_inline_units:
         return units_latex
 
-    match = re.match(r"\\(?:d)?frac{(.*)}{(.*)}", units_latex)
+    match = re.match(r"\\frac{(.*)}{(.*)}", units_latex)
     if not match:
         return units_latex
 

--- a/rubberize/render/md_extensions/irbz.py
+++ b/rubberize/render/md_extensions/irbz.py
@@ -30,7 +30,7 @@ class IrbzProcessor(InlineProcessor):
 
         text_str = ""
         if text_latex.latex:
-            text_str += r"\( " + text_latex.latex + r" \)"
+            text_str += r"\( \displaystyle " + text_latex.latex + r" \)"
         if text_latex.desc:
             text_str += " (" + text_latex.desc.strip() + ")"
         return text_str, m.start(0), m.end(0)


### PR DESCRIPTION
- rank assignments have been rationalized so `sqrt()`, `cbrt()` and `exp()` will be wrapped when exponentiated.
- on the other hand, syntax with obvious wrapping (such as `ceil()`) will retain the original behavior.
- reverts use of `\dfrac` for fraction since it looks wonky for cases where the exponent is a fraction.
- the correct fix for inline fractions should be at render step; `irbz` extension must render with `\displaystyle`, similar to the main `render()` function.