### PR TITLE
fix: preserve mutables from calls in get_object() evals

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ license = {file = "LICENSE"}
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
+    "asteval>=1.0.6,<2.0.0",
     "markdown>=3.7,<4.0",
     "titlecase>=2.4.1,<3.0.0"
 ]

--- a/rubberize/latexer/calls/builtin_calls.py
+++ b/rubberize/latexer/calls/builtin_calls.py
@@ -25,14 +25,13 @@ if TYPE_CHECKING:
     from rubberize.latexer.node_visitors import ExprVisitor
 
 
-def eval_and_convert(
+def get_result_and_convert(
     visitor: "ExprVisitor", call: ast.Call
 ) -> Optional[ExprLatex]:
-    """Common converter that unparses the call node, evaluates it, and
-    then converts the resulting object to latex."""
+    """Common converter that gets the resulting object of a call node's
+    call, and then converts the resulting object to latex."""
 
-    # pylint: disable-next=eval-used
-    obj = eval(ast.unparse(call), visitor.namespace)
+    obj = get_object(call, visitor.namespace)
     return convert_object(obj)
 
 
@@ -268,15 +267,15 @@ def _sum_prod(visitor: "ExprVisitor", call: ast.Call) -> Optional[ExprLatex]:
 
 # fmt: off
 # pylint: disable=line-too-long
-register_call_converter("int", eval_and_convert)
-register_call_converter("float", eval_and_convert)
-register_call_converter("Decimal", eval_and_convert)
-register_call_converter("Fraction", eval_and_convert)
-register_call_converter("complex", eval_and_convert)
-register_call_converter("list", eval_and_convert)
-register_call_converter("tuple", eval_and_convert)
-register_call_converter("set", eval_and_convert)
-register_call_converter("dict", eval_and_convert)
+register_call_converter("int", get_result_and_convert)
+register_call_converter("float", get_result_and_convert)
+register_call_converter("Decimal", get_result_and_convert)
+register_call_converter("Fraction", get_result_and_convert)
+register_call_converter("complex", get_result_and_convert)
+register_call_converter("list", get_result_and_convert)
+register_call_converter("tuple", get_result_and_convert)
+register_call_converter("set", get_result_and_convert)
+register_call_converter("dict", get_result_and_convert)
 register_call_converter("range", _range)
 register_call_converter("abs", lambda v, c: wrap(v, c, r"\left|", r"\right|"))
 register_call_converter("fabs", lambda v, c: wrap(v, c, r"\left|", r"\right|"))

--- a/rubberize/latexer/calls/pint_calls.py
+++ b/rubberize/latexer/calls/pint_calls.py
@@ -3,10 +3,13 @@
 import pint
 
 from rubberize.latexer.calls.convert_call import register_call_converter
-from rubberize.latexer.calls.builtin_calls import eval_and_convert, hide_method
+from rubberize.latexer.calls.builtin_calls import (
+    get_result_and_convert,
+    hide_method,
+)
 
 # fmt: off
-register_call_converter("Quantity", eval_and_convert)
+register_call_converter("Quantity", get_result_and_convert)
 
 register_call_converter("ito", lambda v, c: hide_method(v, c, pint.Quantity))
 register_call_converter("ito_base_units", lambda v, c: hide_method(v, c, pint.Quantity))


### PR DESCRIPTION
- Fixes a bug where mutable objects (such as lists) are changed by `get_object()` if the expression modifies the object (such as` foo.pop()`).
- Switched to `asteval` for a safer `eval()` routine in `get_objects()`. It is now a dependency.
- Refactored call converters to use `get_objects()` instead of it's own `eval()` routine.