### PR TITLE
refactor: get_object()

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ playwright install chromium
 
 ## Basic Usage
 
+> [!WARNING]
+> **Use of `eval()`**: This project uses Python's built-in `eval()` to evaluate some expressions. Since it executes code already present in the input source (e.g., a Jupyter cell or script), it poses no additional risk in such environments. However, be cautious when handling untrusted inputs outside controlled settings.
+
 ### In Jupyter Notebooks
 
 Rubberize must be installed with `pip install rubberize[notebooks]`. Load the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ license = {file = "LICENSE"}
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "asteval>=1.0.6,<2.0.0",
     "markdown>=3.7,<4.0",
     "titlecase>=2.4.1,<3.0.0"
 ]


### PR DESCRIPTION
- Refactored the deepcopy logic so that only referenced names are deepcopied.
- Reverted to `eval()` from `asteval` introduced in #18 for getting the object. Details on the decision is expounded below.
- added a warning in README.

## Why this reverts #18

The previous PR replaced `eval()` with `asteval` to address potential security concerns. However, `asteval` introduces limitations in handling complex numbers, particularly failing to evaluate expressions like `math.e**(1j * math.pi)` (which is mathematical poetry!). This is unacceptable for a library designed to process mathematical expressions.

<img width="857" alt="image" src="https://github.com/user-attachments/assets/8771bdb3-4673-4395-a9f4-2451dce75f17" />

### Why `eval()` is acceptable in this case

- Jupyter users already have execution access, meaning `eval()` does not introduce a new security risk.
`asteval`'s issues may significantly impact usability, making it unsuitable for our purposes.

### Alternatives Considered

- **Fixing `asteval`**: Would require patching asteval internally, which is outside this project's scope.
- **Using `restricted_eval`**: Custom-built solutions are unnecessary given the controlled execution environment in Jupyter.