### PR TITLE
fix: custom converters process

### DIFF
--- a/rubberize/__init__.py
+++ b/rubberize/__init__.py
@@ -10,6 +10,8 @@ from rubberize.latexer import (
     latexer,
     CalcSheet,
     Table,
+    ExprLatex,
+    StmtLatex,
     register_call_converter,
     register_object_converter,
 )

--- a/rubberize/latexer/__init__.py
+++ b/rubberize/latexer/__init__.py
@@ -5,6 +5,8 @@ Python code source string.
 from rubberize.latexer.latexer import latexer
 from rubberize.latexer.components.calcsheet import CalcSheet
 from rubberize.latexer.components.table import Table
+from rubberize.latexer.expr_latex import ExprLatex
+from rubberize.latexer.stmt_latex import StmtLatex
 
 from rubberize.latexer.calls import register_call_converter
 from rubberize.latexer.objects import register_object_converter

--- a/rubberize/latexer/calls/builtin_calls.py
+++ b/rubberize/latexer/calls/builtin_calls.py
@@ -7,111 +7,26 @@ from copy import copy
 from typing import Optional, TYPE_CHECKING
 
 from rubberize.config import config
+from rubberize.latexer.calls.common import (
+    get_result_and_convert,
+    rename,
+    unary,
+    wrap,
+)
 from rubberize.latexer.calls.convert_call import register_call_converter
 from rubberize.latexer.expr_latex import ExprLatex
 from rubberize.latexer.expr_rules import COLLECTIONS_COL, COLLECTIONS_ROW
-from rubberize.latexer.formatters import format_elts, format_delims
-from rubberize.latexer.node_helpers import get_id, get_object, is_method
-from rubberize.latexer.objects import convert_object
+from rubberize.latexer.formatters import format_elts
+from rubberize.latexer.node_helpers import get_id, get_object
 from rubberize.latexer.ranks import (
     get_rank,
     BELOW_POW_RANK,
     BELOW_MULT_RANK,
     BELOW_ADD_RANK,
-    VALUE_RANK,
 )
 
 if TYPE_CHECKING:
     from rubberize.latexer.node_visitors import ExprVisitor
-
-
-def get_result_and_convert(
-    visitor: "ExprVisitor", call: ast.Call
-) -> Optional[ExprLatex]:
-    """Common converter that gets the resulting object of a call node's
-    call, and then converts the resulting object to latex."""
-
-    obj = get_object(call, visitor.namespace)
-    return convert_object(obj)
-
-
-# pylint: disable-next=too-many-arguments
-def wrap(
-    visitor: "ExprVisitor",
-    call: ast.Call,
-    prefix: str,
-    suffix: str,
-    sep: str = r",\, ",
-    *,
-    rank: int = VALUE_RANK,
-) -> ExprLatex:
-    """Common converter that adds prefix and suffix to args."""
-
-    args_latex = [visitor.visit(a).latex for a in call.args]
-    latex = format_elts(args_latex, sep, (prefix, suffix))
-
-    return ExprLatex(latex, rank)
-
-
-def rename(
-    visitor: "ExprVisitor", call: ast.Call, name: str, *, rank: int = VALUE_RANK
-) -> ExprLatex:
-    """Common converter that only changes the operator name."""
-
-    args_latex = [visitor.visit(a).latex for a in call.args]
-    latex = name + format_elts(args_latex, r",\, ", (r"\left(", r"\right)"))
-
-    return ExprLatex(latex, rank)
-
-
-def unary(
-    visitor: "ExprVisitor", call: ast.Call, prefix: str, suffix: str = ""
-) -> ExprLatex:
-    """Common converter for math functions that notationally take only
-    one argument.
-    """
-
-    rank = BELOW_POW_RANK
-
-    name = get_id(call.func)
-    call_arg = call.args[0]
-
-    is_fac_arg = isinstance(call_arg, ast.Call) and (
-        name == "factorial" or get_id(call_arg) == "factorial"
-    )
-    is_pow_arg = isinstance(call_arg, ast.BinOp) and isinstance(
-        call_arg.op, ast.Pow
-    )
-
-    arg = visitor.visit_opd(call_arg, rank, force=is_fac_arg or is_pow_arg)
-    latex = format_delims(arg.latex, (prefix, suffix))
-
-    return ExprLatex(latex, rank)
-
-
-def first_arg(visitor: "ExprVisitor", call: ast.Call) -> ExprLatex:
-    """Common converter that only returns the converted first argument
-    of the call, effectively hiding the call on the first arg.
-    """
-
-    return visitor.visit(call.args[0])
-
-
-def hide_method(
-    visitor: "ExprVisitor", call: ast.Call, cls: type
-) -> Optional[ExprLatex]:
-    """Common converter that visits the parent object of a method
-    call and hides the method call and its arguments.
-    """
-
-    method = get_id(call.func)
-    assert method is not None
-
-    if not is_method(call, cls, method, visitor.namespace):
-        return None
-
-    assert isinstance(call.func, ast.Attribute)
-    return visitor.visit(call.func.value)
 
 
 # pylint: disable-next=too-many-locals

--- a/rubberize/latexer/calls/common.py
+++ b/rubberize/latexer/calls/common.py
@@ -1,0 +1,102 @@
+"""Useful converters."""
+
+import ast
+from typing import Optional, TYPE_CHECKING
+
+from rubberize.latexer.expr_latex import ExprLatex
+from rubberize.latexer.formatters import format_delims, format_elts
+from rubberize.latexer.node_helpers import get_id, get_object, is_method
+from rubberize.latexer.objects import convert_object
+from rubberize.latexer.ranks import BELOW_POW_RANK, VALUE_RANK
+
+if TYPE_CHECKING:
+    from rubberize.latexer.node_visitors import ExprVisitor
+
+
+def get_result_and_convert(
+    visitor: "ExprVisitor", call: ast.Call
+) -> Optional[ExprLatex]:
+    """Common converter that gets the resulting object of a call node's
+    call, and then converts the resulting object to latex."""
+
+    obj = get_object(call, visitor.namespace)
+    return convert_object(obj)
+
+
+# pylint: disable-next=too-many-arguments
+def wrap(
+    visitor: "ExprVisitor",
+    call: ast.Call,
+    prefix: str,
+    suffix: str,
+    sep: str = r",\, ",
+    *,
+    rank: int = VALUE_RANK,
+) -> ExprLatex:
+    """Common converter that adds prefix and suffix to args."""
+
+    args_latex = [visitor.visit(a).latex for a in call.args]
+    latex = format_elts(args_latex, sep, (prefix, suffix))
+
+    return ExprLatex(latex, rank)
+
+
+def rename(
+    visitor: "ExprVisitor", call: ast.Call, name: str, *, rank: int = VALUE_RANK
+) -> ExprLatex:
+    """Common converter that only changes the operator name."""
+
+    args_latex = [visitor.visit(a).latex for a in call.args]
+    latex = name + format_elts(args_latex, r",\, ", (r"\left(", r"\right)"))
+
+    return ExprLatex(latex, rank)
+
+
+def unary(
+    visitor: "ExprVisitor", call: ast.Call, prefix: str, suffix: str = ""
+) -> ExprLatex:
+    """Common converter for math functions that notationally take only
+    one argument.
+    """
+
+    rank = BELOW_POW_RANK
+
+    name = get_id(call.func)
+    call_arg = call.args[0]
+
+    is_fac_arg = isinstance(call_arg, ast.Call) and (
+        name == "factorial" or get_id(call_arg) == "factorial"
+    )
+    is_pow_arg = isinstance(call_arg, ast.BinOp) and isinstance(
+        call_arg.op, ast.Pow
+    )
+
+    arg = visitor.visit_opd(call_arg, rank, force=is_fac_arg or is_pow_arg)
+    latex = format_delims(arg.latex, (prefix, suffix))
+
+    return ExprLatex(latex, rank)
+
+
+def first_arg(visitor: "ExprVisitor", call: ast.Call) -> ExprLatex:
+    """Common converter that only returns the converted first argument
+    of the call, effectively hiding the call on the first arg.
+    """
+
+    return visitor.visit(call.args[0])
+
+
+def hide_method(
+    visitor: "ExprVisitor", call: ast.Call, cls: type
+) -> Optional[ExprLatex]:
+    """Common converter that visits the parent object of a method
+    call and hides the method call and its arguments.
+    """
+
+    method = get_id(call.func)
+    assert method is not None
+
+    if not is_method(call, cls, method, visitor.namespace):
+        return None
+
+    assert isinstance(call.func, ast.Attribute)
+    return visitor.visit(call.func.value)

--- a/rubberize/latexer/calls/common.py
+++ b/rubberize/latexer/calls/common.py
@@ -33,9 +33,32 @@ def wrap(
     *,
     rank: int = VALUE_RANK,
 ) -> ExprLatex:
-    """Common converter that adds prefix and suffix to args."""
+    """Common converter that adds prefix, suffix, and separator to args."""
 
     args_latex = [visitor.visit(a).latex for a in call.args]
+    latex = format_elts(args_latex, sep, (prefix, suffix))
+
+    return ExprLatex(latex, rank)
+
+
+# pylint: disable-next=too-many-arguments
+def wrap_method(
+    visitor: "ExprVisitor",
+    call: ast.Call,
+    prefix: str,
+    suffix: str,
+    sep: str = r",\, ",
+    *,
+    rank: int = VALUE_RANK,
+) -> ExprLatex:
+    """Common converter that adds prefix, suffix, and separator to
+    attribute value and args."""
+
+    assert isinstance(call.func, ast.Attribute)
+
+    args_latex = [visitor.visit(call.func.value).latex]
+    for arg in call.args:
+        args_latex.append(visitor.visit(arg).latex)
     latex = format_elts(args_latex, sep, (prefix, suffix))
 
     return ExprLatex(latex, rank)

--- a/rubberize/latexer/calls/numpy_calls.py
+++ b/rubberize/latexer/calls/numpy_calls.py
@@ -8,7 +8,7 @@ import numpy as np  # pylint: disable=unused-import
 
 from rubberize.latexer.expr_latex import ExprLatex
 from rubberize.latexer.formatters import format_array
-from rubberize.latexer.calls.builtin_calls import unary
+from rubberize.latexer.calls.common import unary
 from rubberize.latexer.calls.convert_call import register_call_converter
 from rubberize.latexer.node_helpers import get_id, is_method
 from rubberize.latexer.ranks import BELOW_MULT_RANK, BELOW_POW_RANK

--- a/rubberize/latexer/calls/pint_calls.py
+++ b/rubberize/latexer/calls/pint_calls.py
@@ -2,11 +2,8 @@
 
 import pint
 
+from rubberize.latexer.calls.common import get_result_and_convert, hide_method
 from rubberize.latexer.calls.convert_call import register_call_converter
-from rubberize.latexer.calls.builtin_calls import (
-    get_result_and_convert,
-    hide_method,
-)
 
 # fmt: off
 register_call_converter("Quantity", get_result_and_convert)

--- a/rubberize/latexer/calls/sympy_calls.py
+++ b/rubberize/latexer/calls/sympy_calls.py
@@ -7,7 +7,7 @@ import sympy as sp
 
 from rubberize import exceptions
 from rubberize.latexer.expr_latex import ExprLatex
-from rubberize.latexer.calls.builtin_calls import hide_method
+from rubberize.latexer.calls.common import hide_method
 from rubberize.latexer.calls.convert_call import register_call_converter
 from rubberize.latexer.node_helpers import get_id, is_method, is_class
 from rubberize.latexer.ranks import BELOW_MULT_RANK

--- a/rubberize/latexer/objects/builtin_objects.py
+++ b/rubberize/latexer/objects/builtin_objects.py
@@ -4,7 +4,7 @@ from decimal import Decimal
 from fractions import Fraction
 from math import floor, log10, isnan, isinf, copysign, degrees, isclose
 from cmath import polar
-from typing import Any, Optional
+from typing import Optional
 
 from rubberize import exceptions
 from rubberize.config import config
@@ -27,18 +27,6 @@ from rubberize.latexer.ranks import (
     BELOW_POW_RANK,
     DIV_RANK,
 )
-
-
-def get_repr_latex(obj: Any) -> ExprLatex:
-    """Common converter to get _repr_latex_() of the object."""
-
-    assert hasattr(obj, "_repr_latex_")
-    return ExprLatex(
-        # pylint: disable-next=protected-access
-        obj._repr_latex_()
-        .strip("$")
-        .replace(r"\displaystyle ", "")
-    )
 
 
 def convert_str(obj: str) -> ExprLatex:

--- a/rubberize/latexer/objects/builtin_objects.py
+++ b/rubberize/latexer/objects/builtin_objects.py
@@ -146,7 +146,7 @@ def _convert_special_num(obj: float | Decimal) -> ExprLatex | None:
     return None
 
 
-def _convert_fraction(obj: Fraction) -> ExprLatex:
+def _fraction(obj: Fraction) -> ExprLatex:
     """Converter for `Fraction` type object."""
 
     numerator = convert_int(obj.numerator)
@@ -270,7 +270,7 @@ register_object_converter(str, convert_str)
 register_object_converter(int, convert_int)
 register_object_converter(float, convert_num)
 register_object_converter(Decimal, convert_num)
-register_object_converter(Fraction, _convert_fraction)
+register_object_converter(Fraction, _fraction)
 register_object_converter(complex, _complex)
 register_object_converter(list, _iters)
 register_object_converter(tuple, _iters)


### PR DESCRIPTION
Fixes (and a feat) to streamline the process of adding custom converters:
- Expose `ExprLatex` and `StmtLatex` to package root for easier access.
- Moved common converters to its own module, so you can import what you need by `from rubberize.latexer.calls.common import ...`
- Added a `wrap_method()` converter which treats `self` as the first argument of the method, allowing you to make it look like a function.