### PR TITLE
refactor: contextual mult routine

### DIFF
--- a/docs/rendering/expressions.md
+++ b/docs/rendering/expressions.md
@@ -48,16 +48,35 @@ a ** b  # Exponentiation
 
 ### Contextual Multiplication Symbol
 
-By default, Rubberize infers which symbol to use for multiplication based on how the operands are rendered. In mathematical notation, different symbols such as the multiplication symbol ($\times$), a dot ($\cdot$), or implicit multiplication (a thin space) are used depending on readability and convention:
+By default, Rubberize infers which symbol to use for multiplication based on how the operands are rendered. In mathematical notation, different symbols such as the multiplication symbol ($\times$), a dot ($\cdot$), or implicit multiplication (a thin space) are used depending on readability and convention.
 
-|         L \ R |   + Number   | - Number | Single  |  Word   |  Call   | Bracketed |
-| ------------: | :----------: | :------: | :-----: | :-----: | :-----: | :-------: |
-|  **+ Number** | $\times$[^1] | $\times$ |  $\ $   |  $\ $   |  $\ $   |   $\ $    |
-|  **- Number** |   $\times$   | $\times$ |  $\ $   |  $\ $   |  $\ $   |   $\ $    |
-|    **Single** |   $\cdot$    | $\cdot$  |  $\ $   | $\cdot$ | $\cdot$ |  $\cdot$  |
-|      **Word** |   $\cdot$    | $\cdot$  | $\cdot$ | $\cdot$ | $\cdot$ |  $\cdot$  |
-|      **Call** |   $\cdot$    | $\cdot$  | $\cdot$ | $\cdot$ | $\cdot$ |  $\cdot$  |
-| **Bracketed** |   $\cdot$    | $\cdot$  |  $\ $   |  $\ $   |  $\ $   |   $\  $   |
+The following table illustrates how Rubberize determines the appropriate multiplication symbol based on the types of operands involved. The row (**L**) represents the left operand, and the column (**R**) represents the right operand. The intersection of a row and a column specifies the multiplication symbol used when those operand types are multiplied.
+
+The operand types are:
+
+- **N**: Numeric values (e.g., $3$, $-2.50$)
+- **L**: Letter variables (a single-character *base name*), including Greek letters, which are rendered in italics (e.g., $x$, $a_{\mathrm{foo}}$, $\epsilon$, $\Delta T$)
+- **W**: Word variables (with multiple characters for *base name*), which are rendered in Roman font (e.g., $\mathrm{foo}$, $\mathrm{var}_{a}$, $\Delta \mathrm{Temp}$)
+- **C**: Function (or class, or method) call. (e.g., $\cos \alpha$, $\mathrm{fcn}(a, b)$ )
+- **B**: Bracketed expressions
+- **?**: Other type not covered (should be explicit)
+
+Signed versions of each type are denoted by the **-** prefix.
+
+|  L \ R |  N  | -N  |  L  | -L  |  W  | -W  |  C  | -C  |  B  | -B  |  ?  | -?  |
+| -----: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
+|  **N** |  ×  |  ×  |     |  ⋅  |     |  ⋅  |     |  ⋅  |     |  ⋅  |  ⋅  |  ⋅  |
+| **-N** |  ×  |  ×  |     |  ⋅  |     |  ⋅  |     |  ⋅  |     |  ⋅  |  ⋅  |  ⋅  |
+|  **L** |  ⋅  |  ⋅  |     |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |
+| **-L** |  ⋅  |  ⋅  |     |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |
+|  **W** |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |
+| **-W** |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |
+|  **C** |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |
+| **-C** |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |
+|  **B** |  ⋅  |  ⋅  |     |  ⋅  |     |  ⋅  |     |  ⋅  |     |  ⋅  |  ⋅  |  ⋅  |
+| **-B** |  ⋅  |  ⋅  |     |  ⋅  |     |  ⋅  |     |  ⋅  |     |  ⋅  |  ⋅  |  ⋅  |
+|  **?** |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |
+| **-?** |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |  ⋅  |
 
 You can turn off this feature and have Rubberize render all multiplication with dot ($\cdot$) by setting the `@use_contextual_mult` config option (a `bool`, default is `True`) to `False`.
 

--- a/rubberize/latexer/calls/common.py
+++ b/rubberize/latexer/calls/common.py
@@ -20,6 +20,8 @@ def get_result_and_convert(
     call, and then converts the resulting object to latex."""
 
     obj = get_object(call, visitor.namespace)
+    if obj is None:
+        return None
     return convert_object(obj)
 
 

--- a/rubberize/latexer/expr_rules.py
+++ b/rubberize/latexer/expr_rules.py
@@ -87,6 +87,9 @@ ACCENTS: dict[str, str] = {
 MODIFIERS: dict[str, str] = {
     "_prime": "'",
     "_star": "^{*}",
+    "_sstar": "^{**}",
+    "_ssstar": "^{***}",
+    "_sssstar": "^{****}",
 }
 
 # Collections syntax

--- a/rubberize/latexer/formatters.py
+++ b/rubberize/latexer/formatters.py
@@ -139,7 +139,7 @@ def _wrap_part(name: str, call: bool = False) -> str:
     if not _is_single_char_part(name):
         return r"\mathrm{" + name + "}"
 
-    return name
+    return f"{{{name}}}" if re.search(r"\^\{\*{1,4}\}$", name) else name
 
 
 def _is_single_char_part(part: str) -> bool:

--- a/rubberize/latexer/latex_patterns.py
+++ b/rubberize/latexer/latex_patterns.py
@@ -8,7 +8,9 @@ assigned a rank based on operator precedence.
 
 import re
 
-DECIMAL_PATTERN = r"\d{1,3}(?:[\s\\{.,'}]{2,3}?\d{3})*(?:.|\{,\})?\d+?"
+DECIMAL_PATTERN = (
+    r"\d{1,3}(?:(?:\\,|\{[,.]\}|\\text\{’\})?\d{3})*(?:(?:\.|\{,\})?\d+)?$"
+)
 
 
 def is_decimal_latex(latex: str) -> bool:

--- a/rubberize/tests/test_node_helpers.py
+++ b/rubberize/tests/test_node_helpers.py
@@ -1,0 +1,81 @@
+"""Tests for node helpers"""
+
+import ast
+import pytest
+
+from rubberize.latexer.node_visitors import ExprVisitor
+from rubberize.latexer.ranks import MULT_RANK
+from rubberize.latexer.node_helpers import get_operand_type
+
+
+def get_expr_node(source: str):
+    """Helper function to parse an expression and return its AST node."""
+    tree = ast.parse(source, mode="eval")
+    return tree.body
+
+
+# Define test cases in a dictionary
+test_cases = {
+    # Numeric values
+    "0": "N",
+    "1": "N",
+    "1000": "N",
+    "-5": "-N",
+    "3.14": "N",
+    "-2.718": "-N",
+    # Sci notation not handled because its always bracketed
+    # Letter variables (single-character base name)
+    "x": "L",
+    "y_foo": "L",
+    "z_hat": "L",
+    "S_star_ult": "L",
+    "epsilon": "L",
+    "DeltaT": "L",
+    "psiQ": "L",
+    "-a": "-L",
+    "-b_foo": "-L",
+    "-c_hat": "-L",
+    "-phiR_n": "-L",
+    # Word variables (multi-character base name)
+    "foo": "W",
+    "bar123": "W",
+    "foo_alpha": "W",
+    "gammaLoad": "W",
+    "-baz_ly": "-W",
+    "-tot_bar": "-W",
+    "-xalpha": "-W",
+    # Function calls
+    "f(x)": "C",
+    "sin(theta)": "C",
+    "foo_baz(a + b)": "C",
+    "-g(y, z)": "-C",
+    "sqrt(x^2 + y^2)": "B",  # Sqrt treated as B
+    "ceil(132.23)": "B",  # Also others that generate brackets
+    "float(3)": "N",  # Should transform to number
+    # # Bracketed expressions
+    "(a + b)": "B",
+    "(x - y)": "B",
+    "-(m + n)": "-B",  # Signed bracketed expression
+    "a / b": "B",  # Div treated as B
+    "a // b": "B",  # Floor div treated as B
+}
+
+
+# Convert to (source, is_left, expected) tuples for pytest
+expanded_cases = [
+    (source, is_left, expected)
+    for source, expected in test_cases.items()
+    for is_left in [True, False]
+]
+
+
+@pytest.mark.parametrize("source, is_left, expected", expanded_cases)
+def test_get_operand_type(source, is_left, expected):
+    """Test get_operand_type()"""
+
+    node = get_expr_node(source)
+    visitor = ExprVisitor()
+    latex = visitor.visit_opd(node, MULT_RANK).latex
+    result = get_operand_type(node, latex, is_left=is_left)
+    print(result)
+    assert result == expected


### PR DESCRIPTION
- Organized the operand types detected by `get_operand_type()`.
- Added a matrix of cases handled by the contextual mult routine in docs and in `get_mult_infix()` docstring.
- Added unit test for `get_operand_type()`

Fixed a few bugs along the way:
- Fixed issue with `get_result_and_convert()` returning an emptyset when it fails. The conversion should return the name for the object.
- Fixed issue with LaTeX generated for names like `xalpha` (where `x` is any character and `alpha` is any Greek letter name) not being wrapped in `\mathrm{...}`. Note that expected result should be `\mathrm{xalpha}`.
- Added multiple stars modifier to names (`foo_sstar` up to `foo_sssstar`).
- Fixed issue with exponentiated names with star modifier (`foo_star`) resulting in error with generated LaTeX when they are exponentiated.