### PR TITLE
fix: handling exponents

### DIFF
--- a/rubberize/latexer/expr_rules.py
+++ b/rubberize/latexer/expr_rules.py
@@ -182,7 +182,7 @@ BIN_OPS: dict[type[ast.operator], _BinOpRule] = {
     ast.Div: _BinOpRule(r"\frac{", "}{", "}", left=_BinOpdRule(wrap=False), right=_BinOpdRule(wrap=False)),
     ast.Mod: _BinOpRule("", r" \mathbin{\%} ", "", right=_BinOpdRule(non_assoc=True)),
     # pylint: disable-next=line-too-long
-    ast.Pow: _BinOpRule("", "^{", "}", left=_BinOpdRule(non_assoc=True), right=_BinOpdRule(wrap=False)),
+    ast.Pow: _BinOpRule("{", "}^{", "}", left=_BinOpdRule(non_assoc=True), right=_BinOpdRule(wrap=False)),
     ast.LShift: _BinOpRule("", r" \ll ", "", right=_BinOpdRule(non_assoc=True)),
     ast.RShift: _BinOpRule("", r" \gg ", "", right=_BinOpdRule(non_assoc=True)),
     ast.BitOr: _BinOpRule("", r" \mathbin{|} ", ""),

--- a/rubberize/latexer/formatters.py
+++ b/rubberize/latexer/formatters.py
@@ -139,7 +139,7 @@ def _wrap_part(name: str, call: bool = False) -> str:
     if not _is_single_char_part(name):
         return r"\mathrm{" + name + "}"
 
-    return f"{{{name}}}" if re.search(r"\^\{\*{1,4}\}$", name) else name
+    return name
 
 
 def _is_single_char_part(part: str) -> bool:


### PR DESCRIPTION
Reverts the previous fix of wrapping a rendered variable name with star (e.g., $L^{*}$) in `{...}`. Instead we should change the rendering on power operations to wrap the base in `{...}` so that we don't add braces unnecessarily.