### PR TITLE
fix: handling exponents 2

### DIFF
--- a/rubberize/__init__.py
+++ b/rubberize/__init__.py
@@ -2,7 +2,7 @@
 documents.
 """
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 
 from rubberize.config import config
 

--- a/rubberize/latexer/expr_rules.py
+++ b/rubberize/latexer/expr_rules.py
@@ -182,7 +182,7 @@ BIN_OPS: dict[type[ast.operator], _BinOpRule] = {
     ast.Div: _BinOpRule(r"\frac{", "}{", "}", left=_BinOpdRule(wrap=False), right=_BinOpdRule(wrap=False)),
     ast.Mod: _BinOpRule("", r" \mathbin{\%} ", "", right=_BinOpdRule(non_assoc=True)),
     # pylint: disable-next=line-too-long
-    ast.Pow: _BinOpRule("{", "}^{", "}", left=_BinOpdRule(non_assoc=True), right=_BinOpdRule(wrap=False)),
+    ast.Pow: _BinOpRule("", "^{", "}", left=_BinOpdRule(non_assoc=True), right=_BinOpdRule(wrap=False)),
     ast.LShift: _BinOpRule("", r" \ll ", "", right=_BinOpdRule(non_assoc=True)),
     ast.RShift: _BinOpRule("", r" \gg ", "", right=_BinOpdRule(non_assoc=True)),
     ast.BitOr: _BinOpRule("", r" \mathbin{|} ", ""),

--- a/rubberize/latexer/node_visitors/expr_visitor.py
+++ b/rubberize/latexer/node_visitors/expr_visitor.py
@@ -106,6 +106,13 @@ class ExprVisitor(ast.NodeVisitor):
         if is_unit_assignment(node, self.namespace):
             return self.visit_unit_assign(node, left, right)
 
+        if (
+            isinstance(node.op, ast.Pow)
+            and isinstance(node.left, ast.Name)
+            and ("^" in left.latex or "_{" in left.latex)
+        ):
+            left.latex = f"{{{left.latex}}}"
+
         if config.use_contextual_mult and isinstance(node.op, ast.Mult):
             infix = get_mult_infix(node, left.latex, right.latex)
             latex = op.prefix + left.latex + infix + right.latex + op.suffix


### PR DESCRIPTION
Hopefully this PR puts the issue of exponents handling to rest 🤞.

Reverts the changes done in #33 and 3406aae95dea2e0523f7e52494f98aa8aa4d5509 (in #31). Instead the variable is only wrapped in `{...}` when it detects that the name is superscripted (`^`) or is subscripted (`_{`). In both cases we should wrap in `{...}` when exponentiating. In the latter case, it is also necessary so the power appears separated from the base ($`{x_{\mathrm{abc}}}^{2}`$ instead of $`x_{\mathrm{abc}}^{2}`$ since this rendering makes 2 look like part of the variable).