### PR TITLE
fix: correct get_desc arg in visit_FunctionDef

### DIFF
--- a/rubberize/latexer/visitors/stmt_visitor.py
+++ b/rubberize/latexer/visitors/stmt_visitor.py
@@ -58,7 +58,7 @@ class StmtVisitor(ast.NodeVisitor):
 
         if isinstance(body[0], ast_c.Comment):
             # inline comment is stored as first item in ast.FunctionDef body
-            desc, cfg = helpers.get_desc(node)
+            desc, cfg = helpers.get_desc(body[0])
             if "hide" in cfg:
                 return StmtLatex(None, desc)
 


### PR DESCRIPTION
This PR fixes an error in `visit_FunctionDef` that misses to parse inline comments attached to the `def` line.