### PR TITLE
fix: various bugfixes

### DIFF
--- a/rubberize/jupyter/magics/tap.py
+++ b/rubberize/jupyter/magics/tap.py
@@ -79,13 +79,13 @@ class TapMagics(Magics):
             local_ns = None
 
         tree = cast(ast_c.Module, ast_c.parse(cell, mode="exec"))
-        latexes = latex_from_ast(tree, local_ns)
+        with config.override(**cfg):
+            latexes = latex_from_ast(tree, local_ns)
         block_starts = _compute_block_starts(cell)
         blocks = _group_blocks(latexes, tree.body, block_starts)
 
         for b in blocks:
-            with config.override(**cfg):
-                html = render(b, local_ns, grid=args.grid)
+            html = render(b, local_ns, grid=args.grid)
 
             if args.html:
                 print(html, "\n")
@@ -127,12 +127,6 @@ class TapMagics(Magics):
             "for compact output."
         ),
     )
-    @argument(
-        "-e",
-        "--show-empty",
-        action="store_true",
-        help="If included, show empty fields in output.",
-    )
     @cell_magic
     def ast(self, line: str, cell: str) -> None:
         """Run the cell and dump its AST."""
@@ -171,7 +165,6 @@ class TapMagics(Magics):
                 annotate_fields=args.annotate_fields,
                 include_attributes=args.include_attributes,
                 indent=args.indent,
-                show_empty=args.show_empty,
             )
 
             print(dump)

--- a/rubberize/latexer/calls/pint_calls.py
+++ b/rubberize/latexer/calls/pint_calls.py
@@ -6,13 +6,13 @@ from rubberize.latexer.calls.common import get_result_and_convert, hide_method
 from rubberize.latexer.calls.convert_call import register_call_converter
 
 # fmt: off
-register_call_converter(pint.Quantity, get_result_and_convert, syntactic=False)
+register_call_converter(pint.Quantity, get_result_and_convert)
 
 register_call_converter(pint.Quantity.ito, hide_method, syntactic=False)
 register_call_converter(pint.Quantity.ito_base_units, hide_method, syntactic=False)
 register_call_converter(pint.Quantity.ito_preferred, hide_method, syntactic=False)
 register_call_converter(pint.Quantity.ito_reduced_units, hide_method, syntactic=False)
-register_call_converter(pint.Quantity.ito_reduced_units, hide_method, syntactic=False)
+register_call_converter(pint.Quantity.ito_root_units, hide_method, syntactic=False)
 
 register_call_converter(pint.Quantity.to, hide_method, syntactic=False)
 register_call_converter(pint.Quantity.to_base_units, hide_method, syntactic=False)

--- a/rubberize/latexer/helpers.py
+++ b/rubberize/latexer/helpers.py
@@ -255,7 +255,7 @@ def is_unit_assignment(node: ast.BinOp, ns: dict[str, object] | None) -> bool:
 def is_ndarray(node: ast.expr, ns: dict[str, object] | None) -> bool:
     """Check if the ast.expr node references a NumPy ndarray.
 
-    If Pint is not installed, returns False.
+    If NumPy is not installed, returns False.
 
     Args:
         node: The ast.expr node to investigate.

--- a/rubberize/latexer/objects/pint_objects.py
+++ b/rubberize/latexer/objects/pint_objects.py
@@ -194,7 +194,7 @@ def _unit(obj: pint.Unit) -> ExprLatex:
     latex = _custom_units_latex.get(units, f"{obj:~L}")
 
     latex = _format_units_latex(latex)
-    rank = ranks.BELOW_MULT_RANK
+    rank = ranks.VALUE_RANK
 
     return ExprLatex(latex, rank)
 

--- a/rubberize/latexer/visitors/expr_visitor.py
+++ b/rubberize/latexer/visitors/expr_visitor.py
@@ -402,13 +402,14 @@ class ExprVisitor(ast.NodeVisitor):
         ):
             return ExprLatex(attr, rank)
 
-        value_rank = ranks.get_rank(node.value)
-        value = self.visit_operand(node.value, value_rank).latex
+        value = self.visit_operand(node.value, rank).latex
 
-        if self.ns and helpers.is_ndarray(node, self.ns):
+        if self.ns and helpers.is_ndarray(node, self.ns) and node.attr == "T":
             latex = value + r"^{\intercal}"
-        else:
-            latex = f"{value}.{attr}"
+            rank = ranks.BELOW_POW_RANK
+            return ExprLatex(latex, rank)
+
+        latex = f"{value}.{attr}"
 
         return ExprLatex(latex, rank)
 


### PR DESCRIPTION
- fix: `%%tap` arguments not applied to the cell source
- fix: allow `pint.Quantity` call to be syntactic since `ureg.Quantity` is not `pint.Quantity`.
- fix: typo for registering `pint.Quantity.ito_root_units`.
- docs: typo in `is_ndarray` helper docstring
- fix: `pint.Unit` expression rank should be `VALUE_RANK`.
- fix: incomplete implementation for `array.T` support.